### PR TITLE
bug(856148): Resolved the rename operation issue in the Azure File Provider.

### DIFF
--- a/Models/AzureFileProvider.cs
+++ b/Models/AzureFileProvider.cs
@@ -388,7 +388,7 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                 {
                     FileManagerDirectoryContent directoryContent = fileItem;
                     isFile = directoryContent.IsFile;
-                    isAlreadyAvailable = isFile ? await IsFileExists(path + newName) : await IsFolderExists(path + newName);
+                    isAlreadyAvailable = await IsFileExists(path + newName);
                     entry.Name = newName;
                     entry.Type = directoryContent.Type;
                     entry.IsFile = isFile;


### PR DESCRIPTION
### Bug description

- Rename operation on folder always returns the error message.

### Root cause

-  The reported issue occurs due to the improper folder exist testing in the provider.

### Solution description

-  Resolved by testing the file/folder exist within the Azure blob storage with proper testing.

### Reason for not identifying earlier
 * [ ] Guidelines not followed. If yes, provide which guideline is not followed.

 * [ ] Guidelines not given. If yes, provide which/who need to address.
    Tag label `update-guideline-coreteam` or `update-guideline-productteam`. 

 * [x] If any other reason, provide the details here. 

#### Areas tested against this fix

- Provide details about the areas or combinations that have been tested against these code changes.

* I have ensured the rename operations of the File Manager.
 
### Is it a breaking issue?
* []  Yes, Tag `breaking-issue`. 
* [x]  NO

 If yes, provide the breaking commit details / MR here.

 ### Output Screenshot
NA

## Reviewer Checklist
* [x]  All provided information are reviewed and ensured.