### PR TITLE
1006275: Resolved the upload issue in File Manager component with azure service.

### DIFF
--- a/Models/AzureFileProvider.cs
+++ b/Models/AzureFileProvider.cs
@@ -621,7 +621,7 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
 
         private async Task PerformUpload(IFormFile file, BlockBlobClient blockBlobClient, BlobClient blockBlob, int chunkIndex, int totalChunk)
         {
-            if (file.ContentType == "application/octet-stream")
+            if (file.ContentType == "application/octet-stream" && totalChunk > 0)
             {
                 using (var fileStream = file.OpenReadStream())
                 {


### PR DESCRIPTION
**Description:**
- Files without extensions were sent with Content-Type "application/octet-stream" and were treated as chunked uploads; StageBlockAsync was called even when there was no chunk information, causing the upload to fail.

**solution:**
- Added a guard so the block-chunk staging/commit logic runs only when chunk metadata is present (i.e., when the upload indicates multiple/any chunks). Otherwise the method uses the single-shot upload path.