### PR TITLE
1007146: Removed Temp File Usage for Single File Download and Replaced HttpClient with Direct Streaming for Private Azure Blob Containers.

### DIFF
--- a/Models/AzureFileProvider.cs
+++ b/Models/AzureFileProvider.cs
@@ -682,12 +682,15 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         relativeFilePath = relativeFilePath.Replace(blobPath, "");
                         // Initialize BlobClient object with the container, relative file path, and the name of the selected item in Azure Blob Storage.
                         BlobClient blockBlob = container.GetBlobClient(relativeFilePath + selectedItems[0].Name);
-                        string absoluteFilePath = Path.GetTempPath() + selectedItems[0].Name;
-                        absoluteFilePath = SanitizeAndValidatePath(absoluteFilePath);
-                        // Copy file from Azure Blob Storage to a temporary location using the CopyFileToTemp method.
-                        await CopyFileToTemp(absoluteFilePath, blockBlob);
-                        FileStream fileStreamInput = new FileStream(absoluteFilePath, FileMode.Open, FileAccess.Read, FileShare.Delete);
-                        FileStreamResult fileStreamResult = new FileStreamResult(fileStreamInput, "APPLICATION/octet-stream");
+
+                        var download = await blockBlob.DownloadStreamingAsync();
+                        string contentType = download.Value.Details.ContentType;
+                        if (string.IsNullOrWhiteSpace(contentType))
+                        {
+                            contentType = "application/octet-stream";
+                        }
+
+                        FileStreamResult fileStreamResult = new FileStreamResult(download.Value.Content, contentType);
                         fileStreamResult.FileDownloadName = selectedItems[0].Name;
                         return fileStreamResult;
                     }
@@ -1021,16 +1024,39 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
         // Returns the image 
         public FileStreamResult GetImage(string path, string id, bool allowCompress, ImageSize size, params FileManagerDirectoryContent[] data)
         {
-            AccessPermission PathPermission = GetFilePermission("Files" + path);
-            if (PathPermission != null && !PathPermission.Read)
+            if (string.IsNullOrWhiteSpace(path))
             {
                 return null;
             }
-            using (HttpClient client = new HttpClient())
+
+            string normalizedPath = path.Replace('\\', '/');
+            string blobName = normalizedPath.TrimStart('/');
+            string normalizedRoot = (rootPath ?? string.Empty).Replace('\\', '/').Trim('/');
+            if (!string.IsNullOrEmpty(normalizedRoot) && !blobName.StartsWith(normalizedRoot + "/", StringComparison.OrdinalIgnoreCase) && !blobName.Equals(normalizedRoot, StringComparison.OrdinalIgnoreCase))
             {
-                var response = client.GetByteArrayAsync(filesPath + path).Result;
-                return new FileStreamResult(new MemoryStream(response), "APPLICATION/octet-stream");
+                blobName = (normalizedRoot + "/" + blobName).Trim('/');
             }
+
+            AccessPermission pathPermission = GetFilePermission(blobName);
+            if (pathPermission != null && !pathPermission.Read)
+            {
+                return null;
+            }
+
+            BlobClient blobClient = container.GetBlobClient(blobName);
+            if (!blobClient.Exists())
+            {
+                return null;
+            }
+
+            var download = blobClient.DownloadStreaming();
+            string contentType = download.Value.Details.ContentType;
+            if (string.IsNullOrWhiteSpace(contentType))
+            {
+                contentType = "application/octet-stream";
+            }
+
+            return new FileStreamResult(download.Value.Content, contentType);
         }
 
         private async Task MoveItems(string sourcePath, string targetPath, string name, string newName)

--- a/Syncfusion.EJ2.FileManager.AzureFileProvider.AspNet.Core.csproj
+++ b/Syncfusion.EJ2.FileManager.AzureFileProvider.AspNet.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
    <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	<MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <RootNamespace>Syncfusion.EJ2.FileManager.AzureFileProvider</RootNamespace>
     <AssemblyName>Syncfusion.EJ2.FileManager.AzureFileProvider</AssemblyName>


### PR DESCRIPTION
Issue: https://github.com/SyncfusionExamples/azure-aspcore-file-provider/issues/15#issuecomment-945489565

To address the issue with downloading images via HttpClient (which fails in the case of private Azure containers), we are updating the GetImage method to stop relying on URL-based downloads. Instead, we will stream the content directly from the already-authenticated Azure Blob container client using the Azure SDK.

This approach ensures that content is served securely and efficiently, without exposing direct URLs, which can break in scenarios involving private containers.

Additionally, we are optimizing the single-file download path by streaming file content directly from Azure Blob Storage, avoiding the use of temporary files. This closely aligns with the behavior of the legacy CloudBlobContainer / CloudBlockBlob classes, maintaining backward compatibility in terms of functionality, while also improving performance and security.

Provided .NET 10 support for the Azure Provider controller.