### PR TITLE
1026295: Resolved  the issues in the azure provider

### DIFF
--- a/Models/AzureFileProvider.cs
+++ b/Models/AzureFileProvider.cs
@@ -471,6 +471,9 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                                 await container.GetBlobClient(SanitizeBlobKey(path + oldName, name, false)).DeleteAsync();
                             }
                         }
+                        
+                        BlobClient oldFolderMarker = container.GetBlobClient(SanitizeBlobKey(path, oldName, true));
+                        await oldFolderMarker.DeleteIfExistsAsync();
                     }
                     renameResponse.Files = details;
                 }
@@ -558,14 +561,16 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                                 BlobClient currentFile = container.GetBlobClient(item.Name);
                                 await currentFile.DeleteAsync();
                             }
-                            entry.Name = fileItem.Name;
-                            entry.Type = fileItem.Type;
-                            entry.IsFile = fileItem.IsFile;
-                            entry.Size = fileItem.Size;
-                            entry.HasChild = fileItem.HasChild;
-                            entry.FilterPath = path;
-                            details.Add(entry);
                         }
+                        BlobClient folderMarker = container.GetBlobClient(SanitizeBlobKey(path, fileItem.Name, true));
+                        await folderMarker.DeleteIfExistsAsync();
+                        entry.Name = fileItem.Name;
+                        entry.Type = fileItem.Type;
+                        entry.IsFile = fileItem.IsFile;
+                        entry.Size = fileItem.Size;
+                        entry.HasChild = fileItem.HasChild;
+                        entry.FilterPath = path;
+                        details.Add(entry);
                     }
                 }
             }
@@ -1288,8 +1293,10 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
         }
         protected virtual string GetPath(string path)
         {
-            String fullPath = (this.blobPath + path);
-            return fullPath;
+            if (path.StartsWith(this.blobPath, StringComparison.OrdinalIgnoreCase))
+                return path;
+
+            return this.blobPath + path;
         }
         protected virtual bool HasPermission(Permission rule)
         {
@@ -1349,6 +1356,19 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         {
                             FilePermission = UpdateFileRules(FilePermission, fileRule);
                         }
+                        else if (currentPath.IndexOf(GetPath(fileRule.Path)) == 0)
+                        {
+                            // Add boundary check - ensure it matches folder boundary with /
+                            string rulePath = GetPath(fileRule.Path);
+                            if (rulePath.EndsWith("/"))
+                            {
+                                FilePermission = UpdateFileRules(FilePermission, fileRule);
+                            }
+                            else if (currentPath.IndexOf(rulePath + "/") == 0)
+                            {
+                                FilePermission = UpdateFileRules(FilePermission, fileRule);
+                            }
+                        }
                     }
                 }
                 return FilePermission;
@@ -1374,7 +1394,26 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         }
                         else if ((location + name).IndexOf(GetPath(folderRule.Path)) == 0)
                         {
-                            FilePermission = UpdateFolderRules(FilePermission, folderRule);
+                            // Add boundary check - ensure it matches folder boundary with /
+                            string rulePath = GetPath(folderRule.Path);
+                            string fullPath = location + name;
+
+                            if (rulePath.EndsWith("/"))
+                            {
+                                // Rule already ends with /, just check prefix
+                                if (fullPath.IndexOf(rulePath) == 0)
+                                {
+                                    FilePermission = UpdateFolderRules(FilePermission, folderRule);
+                                }
+                            }
+                            else
+                            {
+                                // Rule doesn't end with /, add it for proper boundary matching
+                                if (fullPath.IndexOf(rulePath + "/") == 0)
+                                {
+                                    FilePermission = UpdateFolderRules(FilePermission, folderRule);
+                                }
+                            }
                         }
                     }
                 }

--- a/Models/AzureFileProvider.cs
+++ b/Models/AzureFileProvider.cs
@@ -933,6 +933,12 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         accessMessage = permission.Message;
                         throw new UnauthorizedAccessException("'" + path + item.Name + "' is not accessible. You need permission to perform the copy action.");
                     }
+                    AccessPermission targetPermission = GetPathPermission(targetPath, false);
+                    if (targetPermission != null && (!targetPermission.Read || !targetPermission.WriteContents))
+                    {
+                        accessMessage = targetPermission.Message;
+                        throw new UnauthorizedAccessException("'" + this.getFileNameFromPath(targetPath) + "' is not accessible. You need permission to perform the copy action.");
+                    }
                     if (item.IsFile)
                     {
                         if (await IsFileExists(targetPath + item.Name))
@@ -1144,11 +1150,17 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         accessMessage = permission.Message;
                         throw new UnauthorizedAccessException("'" + (path + item.Name) + "' is not accessible. You need permission to perform the write action.");
                     }
-                    AccessPermission PathPermission = GetPathPermission(path, item.IsFile);
+                    AccessPermission PathPermission = GetPathPermission(path, false);
                     if (PathPermission != null && (!PathPermission.Read || !PathPermission.WriteContents))
                     {
                         accessMessage = PathPermission.Message;
                         throw new UnauthorizedAccessException("'" + this.getFileNameFromPath(path) + "' is not accessible. You need permission to perform the write action.");
+                    }
+                    AccessPermission targetPermission = GetPathPermission(targetPath, false);
+                    if (targetPermission != null && (!targetPermission.Read || !targetPermission.WriteContents))
+                    {
+                        accessMessage = targetPermission.Message;
+                        throw new UnauthorizedAccessException("'" + this.getFileNameFromPath(targetPath) + "' is not accessible. You need permission to perform the write action.");
                     }
                     if (item.IsFile)
                     {
@@ -1376,6 +1388,7 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
             else
             {
                 if (this.AccessDetails.AccessRules == null) { return null; }
+                string currentPath = GetPath(location);
                 foreach (AccessRule folderRule in AccessDetails.AccessRules)
                 {
                     if (folderRule.Path != null && folderRule.IsFile == false && (folderRule.Role == null || folderRule.Role == AccessDetails.Role))
@@ -1383,20 +1396,20 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         if (folderRule.Path.IndexOf("*") > -1)
                         {
                             string parentPath = folderRule.Path.Substring(0, folderRule.Path.IndexOf("*"));
-                            if ((location + name).IndexOf(GetPath(parentPath)) == 0 || parentPath == "")
+                            if ((currentPath + name).IndexOf(GetPath(parentPath)) == 0 || parentPath == "")
                             {
                                 FilePermission = UpdateFolderRules(FilePermission, folderRule);
                             }
                         }
-                        else if (GetPath(folderRule.Path) == (location + name) || GetPath(folderRule.Path) == (location + name + Path.DirectorySeparatorChar) || GetPath(folderRule.Path) == (location + name + "/"))
+                        else if (GetPath(folderRule.Path) == (currentPath + name) || GetPath(folderRule.Path) == (currentPath + name + Path.DirectorySeparatorChar) || GetPath(folderRule.Path) == (currentPath + name + "/"))
                         {
                             FilePermission = UpdateFolderRules(FilePermission, folderRule);
                         }
-                        else if ((location + name).IndexOf(GetPath(folderRule.Path)) == 0)
+                        else if ((currentPath + name).IndexOf(GetPath(folderRule.Path)) == 0)
                         {
                             // Add boundary check - ensure it matches folder boundary with /
                             string rulePath = GetPath(folderRule.Path);
-                            string fullPath = location + name;
+                            string fullPath = currentPath + name;
 
                             if (rulePath.EndsWith("/"))
                             {

--- a/Models/AzureFileProvider.cs
+++ b/Models/AzureFileProvider.cs
@@ -1341,7 +1341,9 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         if (fileRule.Path.IndexOf("*.*") > -1)
                         {
                             string parentPath = fileRule.Path.Substring(0, fileRule.Path.IndexOf("*.*"));
-                            if (currentPath.IndexOf(GetPath(parentPath)) == 0 || parentPath == "")
+                            parentPath = parentPath.TrimEnd('/');
+                            string fullPath = (currentPath + name).TrimEnd('/');
+                            if (fullPath.IndexOf(GetPath(parentPath)) == 0 || parentPath == "")
                             {
                                 FilePermission = UpdateFileRules(FilePermission, fileRule);
                             }
@@ -1350,7 +1352,9 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         {
                             string pathExtension = Path.GetExtension(fileRule.Path).ToLower();
                             string parentPath = fileRule.Path.Substring(0, fileRule.Path.IndexOf("*."));
-                            if ((GetPath(parentPath) == currentPath || parentPath == "") && nameExtension == pathExtension)
+                            parentPath = parentPath.TrimEnd('/');
+                            string fullPath = (currentPath + name).TrimEnd('/');
+                            if ((GetPath(parentPath) == fullPath || parentPath == "") && nameExtension == pathExtension)
                             {
                                 FilePermission = UpdateFileRules(FilePermission, fileRule);
                             }
@@ -1359,7 +1363,9 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         {
                             string pathName = Path.GetFileNameWithoutExtension(fileRule.Path);
                             string parentPath = fileRule.Path.Substring(0, fileRule.Path.IndexOf(pathName + ".*"));
-                            if ((GetPath(parentPath) == currentPath || parentPath == "") && fileName == pathName)
+                            parentPath = parentPath.TrimEnd('/');
+                            string fullPath = (currentPath + name).TrimEnd('/');
+                            if ((GetPath(parentPath) == fullPath || parentPath == "") && fileName == pathName)
                             {
                                 FilePermission = UpdateFileRules(FilePermission, fileRule);
                             }
@@ -1396,7 +1402,9 @@ namespace Syncfusion.EJ2.FileManager.AzureFileProvider
                         if (folderRule.Path.IndexOf("*") > -1)
                         {
                             string parentPath = folderRule.Path.Substring(0, folderRule.Path.IndexOf("*"));
-                            if ((currentPath + name).IndexOf(GetPath(parentPath)) == 0 || parentPath == "")
+                            parentPath = parentPath.TrimEnd('/');
+                            string fullPath = (currentPath + name).TrimEnd('/');
+                            if (fullPath.IndexOf(GetPath(parentPath)) == 0 || parentPath == "")
                             {
                                 FilePermission = UpdateFolderRules(FilePermission, folderRule);
                             }


### PR DESCRIPTION
### Issue description
Task - [1026295](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/1026295) - Need to resolve the issues in the provider.

Issue 1: Azure storage url is appending twice for rename operation

Issue 2: Access rule permission is not working for files.

Issue 3: Access rule incorrectly applied for other folders which are not specified in the access rule.

Issue 4: Folder is not deleting from the Ui even though the delete operation is executed.

Issue 5:  While remaining a folder the folder with both old and new name exist in the Ui

Issue 6: Copy/Cut/Paste Operations Not Validating Target Folder Permissions

Issue 7: Azure Storage URL Not Appended for Folder Permission Checks in GetPermission Method

Issue 8: Not able to copy and paste the folder or file in a folder even though its parent folder has permission while using specific format path.

### Root Cause:

Issue 1: 

The [GetPath()] method was being called multiple times without verifying if the Azure storage URL had already been prepended. Each call would add the complete blob path again, resulting in duplicated URLs like: https://...blob.core.windows.net/files/https://...blob.core.windows.net/files/

Issue 2:

When access rules were defined to deny write permissions for files within a specific folder (e.g., deny write for all files in "Files/Video"), the permission matching logic did not properly validate folder boundaries. The code used simple prefix matching without verifying that the file actually belonged to the restricted folder.

Issue 3:

The permission matching logic used simple prefix matching without boundary validation. For example, an access rule defined for "Video" folder would also apply to "Video1" and "Videos" folders because they all contain "Video" as a prefix in their names. This caused unintended permission restrictions on unrelated folders.

Issue 4:

Azure Blob Storage folders are represented by two components: (1) individual file blobs within the folder, and (2) a folder marker blob (an empty blob ending with "/" character). The deletion logic was removing all files within the folder but overlooked deleting the folder marker blob itself. Without removing the marker, the folder continued to appear in the file manager UI.

Issue 5:

The folder rename operation copied all files from the old folder to the new folder and deleted individual files, but did not delete the old folder marker blob (the empty blob representing the folder structure). This left the original folder marker intact while the new folder was created, causing both folder names to appear in the UI.

Issue 6:
The [CopyToAsync] and [MoveToAsync] methods only validated source file/folder permissions before executing the operation. They did not check if the target folder allowed write operations, allowing users to bypass read-only folder restrictions by copying or moving content into restricted folders.

Issue 7:

The [GetPermission] method's folder branch (when [isFile = false]) was comparing unnormalized folder paths directly against access rule paths without prepending the Azure storage blob URL. Since all access rules store full blob URLs, the path comparison failed, causing access rules to not apply to folder operations like delete, rename, and move.

Issue 8:

The current implementation of GetPermission failed to consistently calculate the fullPath of files and folders during rule validation. Discrepancies in handling trailing slashes and improper concatenation of the target location (directory + filename) caused the permission engine to inaccurately evaluate access rules for "Copy & Paste" operations. Because the validation logic for these paths did not correctly normalize boundary checks, the component often failed to recognize valid permissions, blocking copy actions despite them being defined in the rules.

### Solution:

Issue 1:

Added an idempotency check in the [GetPath()] method that verifies whether the path already starts with the blob path before appending it. If the blob path is already present, the method returns the path unchanged, preventing duplicate URL concatenation.

Issue 2:

Added folder boundary checking in the [GetPermission()] method when matching file rules against folder-based access rules. The solution verifies that folder rule paths end with a "/" separator or that the current file path contains the rule path followed by a "/", ensuring files are only restricted when they actually belong to the folder with access restrictions.

Issue 3:

Implemented folder boundary checking using the forward slash "/" delimiter in path comparisons. The system now verifies that matched folders end with a "/" separator to confirm they are actual folder boundaries, not just partial name matches. This ensures rules only apply to explicitly configured folders and their contents.

Issue 4:

Added explicit deletion of the folder marker blob after removing all folder contents. The system now deletes the empty blob representing the folder structure itself, which is the final step required for complete folder removal from both Azure storage and the UI.

Issue 5:

Added deletion of the old folder marker blob after successfully copying all folder contents to the new folder name. Similar to the deletion fix, this targets the folder structure marker itself, ensuring complete folder rename operations that fully remove the old folder from both storage and UI.

Issue 6:

Added target folder permission validation in both [CopyToAsync]) and [MoveToAsync] methods. Before executing copy or move operations, the provider now checks if the target folder has [Read] and [WriteContents] permissions. If either permission is denied, an [UnauthorizedAccessException] is thrown to prevent the operation.

Issue 7:

Modified the folder branch in the [GetPermission] method to call [GetPath(location)] at the start, which normalizes the path by prepending the Azure blob storage URL. All subsequent path comparisons now use the normalized [currentPath] variable, ensuring consistency with how file permissions are checked and allowing access rules to be properly matched and enforced for folder operations.

Issue 8:

The solution involves standardizing path comparisons within the GetPermission method to ensure consistent behavior across different file operations. We have implemented path normalization by applying TrimEnd('/') to all parentPath and fullPath calculations, which effectively eliminates errors caused by inconsistent trailing slashes when determining file locations. Furthermore, we refined the fullPath construction logic to ensure that currentPath and the file or folder name are joined correctly, mapping precisely to the intended destination during rule evaluation. By updating the wildcard and prefix-matching logic to verify these normalized paths against rule boundaries, the permission engine can now correctly identify and apply the appropriate AccessPermission settings for copy operations. These adjustments provide a reliable and deterministic validation process, ensuring that permitted copy actions are accurately processed in the same manner as cut operations.

### AI Usage:
Code Studio used in this PR/MR? (Yes)
If Yes: Primary use (choose one)
* [ ] Generate new code
* [ ] Refactor/improve existing code
* [ ] Tests
* [X] Bug fix / debugging help
* [ ] Docs / comments
* [x] Review assistance (explanations/summaries)
* [ ] Other

Outcome (Saved time)

### Requirement and specification document
* [x] API Review (Task link: -)
* [x] Azure Task with detailed feature information (Task link:)
* [ ] Not applicable

### Feature scope and impact
* [ ] Core functionality (high impact)
* [x] Enhancement to existing feature
* [ ] New standalone feature
* [ ] Experimental feature

### Output screenshots/demos



### Feature matrix documentation
* [ ] Feature matrix document updated [Centralized location](https://syncfusion.sharepoint.com/:f:/r/sites/Blazor/Shared%20Documents/Feature%20Matrix%20-%20Documents?csf=1&web=1&e=OGX1td)
* [x] Not applicable

### Testing coverage
* [x] Ensured the folder delete operation is working correctly.
* [X] Ensured the access rules were applying correctly for the files.
* [X] Ensured the old, renamed folders were deleted and only shows the folder with new name. 
* [X] Ensured the rename operation not appending the azure storage url twice.
* [X] Ensured the access rules were correctly applying for the specified folders rather than applying for folder starts with same name.
* [X] Ensured all the access rule conditions were working correctly.
* [X] Ensured all the access rule functionalities were applied correctly.
* [X] Ensured the cut ,copy ,paste operations were denied when target folder does not have permission.


### Test cases and automation
* [ ] Test cases documented and attached to this PR
* [x] BUnit tests added (PR link: Automation work assigned to testing team to avoid this in the future)
* [ ] Playwright tests added (PR link: _________________)
* [ ] Manual testing only (justification: _________________)
* [ ] Not applicable

### Test bed sample location
Provide the test bed sample location for code reviewers to verify the feature's behavior.
 
### Platform verification
* [x] Verified in Blazor Server
* [x] Verified in Blazor WASM
* [ ] Not applicable

### Related components
* [ ] Feature applicable to other components (Tasks created: _________________) (tagged "needs-attention-coreteam")
* [x] Not applicable to other components

### Breaking changes
* [ ] Contains breaking changes - provide migration guidance (added "breaking-change" label)
* [x] No breaking changes

### Performance verification
* [x] Memory usage verified (no leaks)
* [x] Rendering performance verified
* [ ] Not applicable

### Reviewer Checklist
* [ ] Feature matrix documentation verified
* [ ] Test coverage verified
* [ ] Sample implementation reviewed
* [ ] Code meets standards and best practices
* [ ] C# implementation used appropriately (minimal JavaScript)